### PR TITLE
US4914 Ability documentation and metadata

### DIFF
--- a/app/models/mongoidable/abilities.rb
+++ b/app/models/mongoidable/abilities.rb
@@ -4,9 +4,40 @@
 module Mongoidable
   class Abilities
     include ::CanCan::Ability
+    attr_reader :ability_source
+    attr_accessor :rule_type
+
+    def initialize(ability_source)
+      @ability_source = ability_source
+      @rule_type = :adhoc
+    end
 
     def to_casl_list
       rules.map { |rule| Mongoidable::CaslHash.new(rule) }
+    end
+
+    def class_abilities
+      self.rule_type = :static
+      yield
+    ensure
+      self.rule_type = :adhoc
+    end
+
+    def cannot(action = nil, subject = nil, *attributes_and_conditions, &block)
+      extra = set_rule_extras(attributes_and_conditions)
+      super(action, subject, *extra, &block)
+    end
+
+    def can(action = nil, subject = nil, *attributes_and_conditions, &block)
+      extra = set_rule_extras(attributes_and_conditions)
+      super(action, subject, *extra, &block)
+    end
+
+    def set_rule_extras(extra)
+      extra = [{}] if extra.empty?
+      extra.first[:rule_source] = ability_source unless extra.first.key?(:rule_source)
+      extra.first[:rule_type] = rule_type
+      extra
     end
   end
 end

--- a/app/models/mongoidable/ability.rb
+++ b/app/models/mongoidable/ability.rb
@@ -23,9 +23,5 @@ module Mongoidable
     validates_presence_of :base_behavior
 
     embedded_in :instance_abilities
-
-    def to_a
-      [action, subject, extra]
-    end
   end
 end

--- a/app/models/mongoidable/ability.rb
+++ b/app/models/mongoidable/ability.rb
@@ -23,5 +23,9 @@ module Mongoidable
     validates_presence_of :base_behavior
 
     embedded_in :instance_abilities
+
+    def description
+      I18n.t("mongoidable.ability.description.#{action}", subject: self[:subject])
+    end
   end
 end

--- a/lib/mongoidable.rb
+++ b/lib/mongoidable.rb
@@ -11,6 +11,8 @@ require "ruby2js"
 require "ruby2js/filter/return"
 
 require "mongoidable/active_record_disabler"
+require "mongoidable/rule"
+
 require "mongoidable/casl_hash"
 require "mongoidable/class_abilities"
 require "mongoidable/class_type"

--- a/lib/mongoidable/casl_hash.rb
+++ b/lib/mongoidable/casl_hash.rb
@@ -10,7 +10,9 @@ module Mongoidable
       self.inverted = rule
       self.block = rule
       self.source = rule
-      self[:description] = rule.actions.map { |action| I18n.t("mongoidable.ability.description.#{action}") }.join("/")
+      self[:description] = rule.actions.map do |action|
+        I18n.t("mongoidable.ability.description.#{action}", subject: self[:subject])
+      end.join("/")
       self[:type] = rule.rule_type
     end
 

--- a/lib/mongoidable/casl_hash.rb
+++ b/lib/mongoidable/casl_hash.rb
@@ -9,12 +9,19 @@ module Mongoidable
       self.conditions = rule
       self.inverted = rule
       self.block = rule
+      self.source = rule
+      self[:description] = rule.actions.map { |action| I18n.t("mongoidable.ability.description.#{action}") }.join("/")
+      self[:type] = rule.rule_type
     end
 
     private
 
     def actions=(rule)
       self[:actions] = rule.actions
+    end
+
+    def source=(rule)
+      self[:source] = rule.rule_source if rule.rule_source
     end
 
     def subject=(rule)

--- a/lib/mongoidable/casl_hash.rb
+++ b/lib/mongoidable/casl_hash.rb
@@ -4,7 +4,7 @@
 module Mongoidable
   class CaslHash < Hash
     def initialize(rule)
-      self.actions = rule
+      self.action = rule
       self.subject = rule
       self.conditions = rule
       self.inverted = rule
@@ -18,8 +18,8 @@ module Mongoidable
 
     private
 
-    def actions=(rule)
-      self[:actions] = rule.actions
+    def action=(rule)
+      self[:action] = rule.actions
     end
 
     def source=(rule)

--- a/lib/mongoidable/casl_hash.rb
+++ b/lib/mongoidable/casl_hash.rb
@@ -23,7 +23,7 @@ module Mongoidable
     end
 
     def source=(rule)
-      self[:source] = rule.rule_source if rule.rule_source
+      self[:source] = rule.rule_source.presence
     end
 
     def subject=(rule)

--- a/lib/mongoidable/class_abilities.rb
+++ b/lib/mongoidable/class_abilities.rb
@@ -7,13 +7,11 @@ module Mongoidable
 
     # rubocop:disable Metrics/BlockLength
     class_methods do
+      attr_reader :ability_definition
+
       # The static abilities of this class and abilities inherited from base classes
       def define_abilities(&block)
         @ability_definition = block.to_proc
-      end
-
-      def ability_definition
-        @ability_definition
       end
 
       def ancestral_abilities

--- a/lib/mongoidable/current_ability.rb
+++ b/lib/mongoidable/current_ability.rb
@@ -9,7 +9,7 @@ module Mongoidable
   #   own instance abilities
   module CurrentAbility
     def current_ability
-      abilities = Mongoidable::Abilities.new
+      abilities = Mongoidable::Abilities.new(mongoidable_identity)
       add_inherited_abilities(abilities)
       add_ancestral_abilities(abilities)
       abilities.merge(own_abilities)
@@ -34,7 +34,9 @@ module Mongoidable
 
     def add_ancestral_abilities(abilities)
       self.class.ancestral_abilities.each do |ancestral_ability|
-        ancestral_ability.call(abilities, self)
+        abilities.class_abilities do
+          ancestral_ability.call(abilities, self)
+        end
       end
     end
   end

--- a/lib/mongoidable/instance_abilities.rb
+++ b/lib/mongoidable/instance_abilities.rb
@@ -5,8 +5,15 @@ module Mongoidable
   module InstanceAbilities
     private
 
+    def mongoidable_identity
+      {
+          model: model_name.name,
+          id:    id
+      }
+    end
+
     def own_abilities
-      own_abilities = Mongoidable::Abilities.new
+      own_abilities = Mongoidable::Abilities.new(mongoidable_identity)
       instance_abilities.each do |ability|
         if ability.base_behavior
           own_abilities.can(ability.action, ability.subject, *ability.extra)

--- a/lib/mongoidable/rule.rb
+++ b/lib/mongoidable/rule.rb
@@ -1,0 +1,16 @@
+require "cancan/rule"
+
+module CanCan
+  module RuleExtentions
+    attr_reader :rule_source, :rule_type
+
+    def initialize(base_behavior, action, subject, *extra_args, &block)
+      @rule_source = extra_args.first&.delete(:rule_source)
+      @rule_type = extra_args.first&.delete(:rule_type)
+      extra_args.shift if extra_args.first&.empty?
+      super
+    end
+  end
+end
+
+CanCan::Rule.prepend(CanCan::RuleExtentions)

--- a/spec/casl_hash_spec.rb
+++ b/spec/casl_hash_spec.rb
@@ -44,12 +44,4 @@ RSpec.describe "casl_hash" do
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash).not_to be_key(:block)
   end
-
-  it "adds the block as js when present" do
-    rule = CanCan::Rule.new(false, :action, User) do
-      1 + 1
-    end
-    hash = Mongoidable::CaslHash.new(rule)
-    expect(hash[:block]).to eq "var rule = new CanCan.Rule(false, \"action\", User, function() {\n  return 1 + 1\n})"
-  end
 end

--- a/spec/casl_hash_spec.rb
+++ b/spec/casl_hash_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "casl_hash" do
   it "sets the action" do
     rule = CanCan::Rule.new(false, :action, User)
     hash = Mongoidable::CaslHash.new(rule)
-    expect(hash[:actions]).to eq [:action]
+    expect(hash[:action]).to eq [:action]
   end
   it "sets the subject when a symbol" do
     rule = CanCan::Rule.new(false, :action, :subject)

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Mongoidable::Abilities do
               source:      "test",
               has_block:   false,
               subject:     [:to_thing],
-              actions:     [:do_thing],
+              action:      [:do_thing],
               description: "translation missing: en.mongoidable.ability.description.do_thing"
           },
           {
@@ -21,7 +21,7 @@ RSpec.describe Mongoidable::Abilities do
               inverted:    true,
               conditions:  { name: "Fred" },
               subject:     ["User"],
-              actions:     [:do_other_thing],
+              action:      [:do_other_thing],
               description: "translation missing: en.mongoidable.ability.description.do_other_thing"
           },
           {
@@ -31,7 +31,7 @@ RSpec.describe Mongoidable::Abilities do
               block_ruby:  "abilities.can(:do_block_thing, User) do |user|\n        user.name == \"Fred\"\n      end",
               block_js:    "abilities.can(\"do_block_thing\", User, function(user) {\n  return user.name == \"Fred\"\n})",
               subject:     ["User"],
-              actions:     [:do_block_thing],
+              action:      [:do_block_thing],
               description: "translation missing: en.mongoidable.ability.description.do_block_thing"
           }
       ]

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Mongoidable::Abilities do
               has_block:   false,
               subject:     [:to_thing],
               actions:     [:do_thing],
-              description: "translation missing: en.mongoidable.do_thing"
+              description: "translation missing: en.mongoidable.ability.description.do_thing"
           },
           {
               type:        :adhoc,
@@ -22,7 +22,7 @@ RSpec.describe Mongoidable::Abilities do
               conditions:  { name: "Fred" },
               subject:     ["User"],
               actions:     [:do_other_thing],
-              description: "translation missing: en.mongoidable.do_other_thing"
+              description: "translation missing: en.mongoidable.ability.description.do_other_thing"
           },
           {
               type:        :adhoc,
@@ -32,7 +32,7 @@ RSpec.describe Mongoidable::Abilities do
               block_js:    "abilities.can(\"do_block_thing\", User, function(user) {\n  return user.name == \"Fred\"\n})",
               subject:     ["User"],
               actions:     [:do_block_thing],
-              description: "translation missing: en.mongoidable.do_block_thing"
+              description: "translation missing: en.mongoidable.ability.description.do_block_thing"
           }
       ]
     end

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -4,105 +4,76 @@ require "rails_helper"
 
 RSpec.describe Mongoidable::Abilities do
   describe "to_list" do
+    let(:expected_result) do
+      [
+          {
+              type:        :adhoc,
+              source:      "test",
+              has_block:   false,
+              subject:     [:to_thing],
+              actions:     [:do_thing],
+              description: "translation missing: en.mongoidable.do_thing"
+          },
+          {
+              type:        :adhoc,
+              source:      "test",
+              has_block:   false,
+              inverted:    true,
+              conditions:  { name: "Fred" },
+              subject:     ["User"],
+              actions:     [:do_other_thing],
+              description: "translation missing: en.mongoidable.do_other_thing"
+          },
+          {
+              type:        :adhoc,
+              source:      "test",
+              has_block:   true,
+              block_ruby:  "abilities.can(:do_block_thing, User) do |user|\n        user.name == \"Fred\"\n      end",
+              block_js:    "abilities.can(\"do_block_thing\", User, function(user) {\n  return user.name == \"Fred\"\n})",
+              subject:     ["User"],
+              actions:     [:do_block_thing],
+              description: "translation missing: en.mongoidable.do_block_thing"
+          }
+      ]
+    end
     it "produces a casl list of rules" do
-      abilities = Mongoidable::Abilities.new
+      abilities = Mongoidable::Abilities.new("test")
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|
         user.name == "Fred"
       end
-
-      expect(abilities.to_casl_list).to eq(
-          [
-              {
-                  actions:   [:do_thing],
-                  subject:   [:to_thing],
-                  has_block: false
-              },
-              {
-                  actions:    [:do_other_thing],
-                  conditions: { name: "Fred" },
-                  inverted:   true,
-                  subject:    ["User"],
-                  has_block:  false
-              },
-              {
-                  actions:    [:do_block_thing],
-                  subject:    ["User"],
-                  has_block:  true,
-                  block_js:   "abilities.can(\"do_block_thing\", User, function(user) {\n  return user.name == \"Fred\"\n})",
-                  block_ruby: "abilities.can(:do_block_thing, User) do |user|\n        user.name == \"Fred\"\n      end"
-              }
-          ]
-        )
+      expect(abilities.to_casl_list).to eq(expected_result)
     end
 
     it "produces a casl list of rules without js closure" do
       allow(Mongoidable.configuration).to receive(:serialize_js).and_return(false)
 
-      abilities = Mongoidable::Abilities.new
+      abilities = Mongoidable::Abilities.new("test")
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|
         user.name == "Fred"
       end
 
-      expect(abilities.to_casl_list).to eq(
-          [
-              {
-                  actions:   [:do_thing],
-                  subject:   [:to_thing],
-                  has_block: false
-              },
-              {
-                  actions:    [:do_other_thing],
-                  conditions: { name: "Fred" },
-                  inverted:   true,
-                  subject:    ["User"],
-                  has_block:  false
-              },
-              {
-                  actions:    [:do_block_thing],
-                  subject:    ["User"],
-                  has_block:  true,
-                  block_ruby: "abilities.can(:do_block_thing, User) do |user|\n        user.name == \"Fred\"\n      end"
-              }
-          ]
-        )
+      expected_result[2].delete(:block_js)
+
+      expect(abilities.to_casl_list).to eq(expected_result)
     end
 
     it "produces a casl list of rules without ruby block" do
       allow(Mongoidable.configuration).to receive(:serialize_ruby).and_return(false)
 
-      abilities = Mongoidable::Abilities.new
+      abilities = Mongoidable::Abilities.new("test")
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|
         user.name == "Fred"
       end
 
-      expect(abilities.to_casl_list).to eq(
-          [
-              {
-                  actions:   [:do_thing],
-                  subject:   [:to_thing],
-                  has_block: false
-              },
-              {
-                  actions:    [:do_other_thing],
-                  conditions: { name: "Fred" },
-                  inverted:   true,
-                  subject:    ["User"],
-                  has_block:  false
-              },
-              {
-                  actions:   [:do_block_thing],
-                  subject:   ["User"],
-                  has_block: true,
-                  block_js:  "abilities.can(\"do_block_thing\", User, function(user) {\n  return user.name == \"Fred\"\n})"
-              }
-          ]
-        )
+      expected_result[2].delete(:block_ruby)
+
+      expect(abilities.to_casl_list).to eq(expected_result)
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -27,4 +27,21 @@ RSpec.describe Mongoidable::Ability do
     expect(main_instance.current_ability.can?(:do_something, other_instance)).to be_truthy
     expect(main_instance.current_ability.can?(:do_something, main_instance)).to  be_falsey
   end
+
+  it "adds the instance ability source to the rule" do
+    main_instance = User.new(id: 1)
+    main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
+    list = main_instance.current_ability.to_casl_list
+    expect(list[2][:source]).to eq ({:id=>1, :model=>"User"})
+  end
+
+  it "adds the ability action description to the rule" do
+    main_instance = User.new(id: 1)
+    main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
+    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_user_class_stuff").and_return("This is my do_user_class_stuff description")
+    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_other_user_class_stuff").and_return("This is my do_other_user_class_stuff description")
+    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_something").and_return("This is my do_something description")
+    list = main_instance.current_ability.to_casl_list
+    expect(list[2][:description]).to eq "This is my do_something description"
+  end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -38,9 +38,15 @@ RSpec.describe Mongoidable::Ability do
   it "adds the ability action description to the rule" do
     main_instance = User.new(id: 1)
     main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
-    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_user_class_stuff").and_return("This is my do_user_class_stuff description")
-    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_other_user_class_stuff").and_return("This is my do_other_user_class_stuff description")
-    allow(I18n).to receive(:t).with("mongoidable.ability.description.do_something").and_return("This is my do_something description")
+    allow(I18n).to receive(:t).
+        with("mongoidable.ability.description.do_user_class_stuff", {:subject=>["User"]}).
+        and_return("This is my do_user_class_stuff description")
+    allow(I18n).to receive(:t).
+        with("mongoidable.ability.description.do_other_user_class_stuff", {:subject=>["User"]}).
+        and_return("This is my do_other_user_class_stuff description")
+    allow(I18n).to receive(:t).
+        with("mongoidable.ability.description.do_something", {:subject=>["User"]}).
+        and_return("This is my do_something description")
     list = main_instance.current_ability.to_casl_list
     expect(list[2][:description]).to eq "This is my do_something description"
   end


### PR DESCRIPTION
Adds the following metadata to the serialization

:source=>{:model=>"Abilities::Roles::Member", :id=>"5f3d932a11b801633bc9eb02"}, 
:description=>"Can read [\"Account\"]", :
type=>"static"}

Where source is the class and mongoid id, description is an i18n string translation and type is either static or adhoc.