### PR TITLE
Jmr/mongoidable cache version 2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,10 @@
-require: rubocop-performance
+require:
+  - rubocop/require_tools
+  - rubocop-i18n
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
+  - rubocop-thread_safety
 
 AllCops:
   TargetRubyVersion: 2.7
@@ -12,6 +18,7 @@ AllCops:
     - 'config.ru'
     - 'bin/**/*'
     - 'node_modules/**/*'
+  NewCops: enable
   UseCache: false
 
 Layout/BlockAlignment:

--- a/app/models/mongoidable/abilities.rb
+++ b/app/models/mongoidable/abilities.rb
@@ -6,17 +6,34 @@ module Mongoidable
     include ::CanCan::Ability
     include Mongoidable::CaslList
 
-    attr_reader :ability_source
+    attr_reader :ability_source, :parent_model
     attr_accessor :rule_type
 
-    def initialize(ability_source)
+    def initialize(ability_source, parent_model)
+      @parent_model = parent_model
       @ability_source = ability_source
       @rule_type = :adhoc
+    end
+
+    def cannot?(*args)
+      if can_cache?
+        Rails.cache.fetch(ability_cache_key(args)) { super }
+      else
+        super
+      end
     end
 
     def cannot(action = nil, subject = nil, *attributes_and_conditions, &block)
       extra = set_rule_extras(attributes_and_conditions)
       super(action, subject, *extra, &block)
+    end
+
+    def can?(*args)
+      if can_cache?
+        Rails.cache.fetch(ability_cache_key(args)) { super }
+      else
+        super
+      end
     end
 
     def can(action = nil, subject = nil, *attributes_and_conditions, &block)
@@ -28,39 +45,25 @@ module Mongoidable
       extra = [{}] if extra.empty?
       extra.first[:rule_source] = ability_source unless extra.first.key?(:rule_source)
       extra.first[:rule_type] = rule_type
-      extra.first[:parent] = self
       extra
     end
 
     private
 
-    def marshal_dump
-      { ability_source: @ability_source, rule_type: @rule_type, rules: @rules, aliased_actions: @aliased_actions }
+    def can_cache?
+      parent_model.present? && config.enable_caching
     end
 
-    def marshal_load(hash)
-      @ability_source = hash[:ability_source]
-      @rule_type = hash[:rule_type]
-      @rules = hash[:rules]
-      @aliased_actions = hash[:aliased_actions]
+    def config
+      Mongoidable.configuration
+    end
 
-      rules = @rules.clone
-      @rules = []
-      rules&.each do |rule|
-        # If the rule had a block, the entire block defines the rule
-        block = rule.serialized_block
-        if block&.is_a?(String)
-          # evaluate the block which will add a new rule. Eval the block to re-add the rule
-          rule.abilities = self
-          rule.send(:eval, block)
-          # since the block was evaled, not read from file, we will have to stash the string
-          # version of the block in case we need to serialize it again.
-          @rules.last.serialized_block = block
-        else
-          # this rule has no block, just index it
-          add_rule(rule)
-        end
-      end
+    def ability_cache_key(args)
+      "#{config.cache_key_prefix}/#{parent_model.cache_key}/#{args}"
+    end
+
+    def ability_cache_expiration
+      config.cache_ttl.seconds
     end
   end
 end

--- a/app/models/mongoidable/abilities.rb
+++ b/app/models/mongoidable/abilities.rb
@@ -17,7 +17,7 @@ module Mongoidable
 
     def cannot?(*args)
       if can_cache?
-        Rails.cache.fetch(ability_cache_key(args)) { super }
+        Rails.cache.fetch(ability_cache_key(args), cache_options) { super }
       else
         super
       end
@@ -30,7 +30,7 @@ module Mongoidable
 
     def can?(*args)
       if can_cache?
-        Rails.cache.fetch(ability_cache_key(args)) { super }
+        Rails.cache.fetch(ability_cache_key(args), cache_options) { super }
       else
         super
       end
@@ -64,6 +64,13 @@ module Mongoidable
 
     def ability_cache_expiration
       config.cache_ttl.seconds
+    end
+
+    def cache_options
+      {
+          expires_in:         ability_cache_expiration,
+          race_condition_ttl: 10.seconds
+      }
     end
   end
 end

--- a/app/models/mongoidable/ability.rb
+++ b/app/models/mongoidable/ability.rb
@@ -16,15 +16,15 @@ module Mongoidable
     # Extra arguments as defined by cancancan.
     field :extra, type: Array
 
-    validates_presence_of :action
+    validates :action, presence: true
     validate :subject do |object|
-      raise ArgumentError, ":subject cannot be blank" if object.subject.nil?
+      raise ArgumentError, _(":subject cannot be blank") if object.subject.nil?
     end
-    validates_presence_of :base_behavior
+    validates :base_behavior, presence: true
 
     embedded_in :instance_abilities, touch: true
-    after_save :touch_parent
     after_destroy :touch_parent
+    after_save :touch_parent
 
     def description
       I18n.t("mongoidable.ability.description.#{action}", subject: self[:subject])
@@ -33,7 +33,7 @@ module Mongoidable
     private
 
     def touch_parent
-      self._parent.touch
+      _parent.touch
     end
   end
 end

--- a/app/models/mongoidable/ability.rb
+++ b/app/models/mongoidable/ability.rb
@@ -18,7 +18,7 @@ module Mongoidable
 
     validates :action, presence: true
     validate :subject do |object|
-      raise ArgumentError, _(":subject cannot be blank") if object.subject.nil?
+      raise ArgumentError, ":subject cannot be blank" if object.subject.nil?
     end
     validates :base_behavior, presence: true
 

--- a/lib/mongoidable/casl_hash.rb
+++ b/lib/mongoidable/casl_hash.rb
@@ -14,6 +14,7 @@ module Mongoidable
         I18n.t("mongoidable.ability.description.#{action}", subject: self[:subject])
       end.join("/")
       self[:type] = rule.rule_type
+      super
     end
 
     private
@@ -31,7 +32,7 @@ module Mongoidable
     end
 
     def conditions=(rule)
-      self[:conditions] = rule.conditions unless rule.conditions.blank?
+      self[:conditions] = rule.conditions if rule.conditions.present?
     end
 
     def inverted=(rule)

--- a/lib/mongoidable/class_abilities.rb
+++ b/lib/mongoidable/class_abilities.rb
@@ -61,7 +61,7 @@ module Mongoidable
       end
 
       def singular_relation?(relation)
-        !relation.relation.macro.to_s.include?("many")
+        relation.relation.macro.to_s.exclude?("many")
       end
     end
     # rubocop:enable Metrics/BlockLength

--- a/lib/mongoidable/current_ability.rb
+++ b/lib/mongoidable/current_ability.rb
@@ -10,46 +10,32 @@ module Mongoidable
   module CurrentAbility
     attr_accessor :parent_model
 
-    def current_ability(parent = nil, skip_cache: false)
-      with_ability_cache(skip_cache) do
-        if defined?(Mongoidable::RSpec) && !Mongoidable::RSpec.configuration.with_abilities
-          return Mongoidable::RSpec::AbilitiesTestStub.new(mongoidable_identity)
-        else
-          abilities = Mongoidable::Abilities.new(mongoidable_identity)
-          add_inherited_abilities(abilities, skip_cache)
-          add_ancestral_abilities(abilities, parent)
-          abilities.merge(own_abilities)
-        end
+    def current_ability(parent = nil)
+      if defined?(Mongoidable::RSpec) && !Mongoidable::RSpec.configuration.with_abilities
+        Mongoidable::RSpec::AbilitiesTestStub.new(mongoidable_identity)
+      else
+        abilities = Mongoidable::Abilities.new(mongoidable_identity, parent || self)
+        add_inherited_abilities(abilities)
+        add_ancestral_abilities(abilities, parent)
+        abilities.merge(own_abilities)
       end
     end
 
     private
 
-    def should_cache?
-      config.enable_caching
-    end
-
-    def with_ability_cache(skip_cache, &block)
-      if should_cache? && !skip_cache
-        Rails.cache.fetch(ability_cache_key, expires_in: ability_cache_expiration, &block)
-      else
-        yield
-      end
-    end
-
-    def add_inherited_abilities(abilities, skip_cache)
+    def add_inherited_abilities(abilities)
       self.class.inherits_from.reduce(abilities) do |sum, inherited_from|
         relation = send(inherited_from[:name])
-        next sum unless relation.present?
+        next sum if relation.blank?
 
         order_by = inherited_from[:order_by]
         descending = inherited_from[:direction] == :desc
-        next sum unless relation.present?
+        next sum if relation.blank?
 
         relations = Array.wrap(relation)
         relations.sort_by! { |item| item.send(order_by) } if order_by
         relations.reverse! if descending
-        relations.each { |object| sum.merge(object.current_ability(self, skip_cache: skip_cache)) }
+        relations.each { |object| sum.merge(object.current_ability(self)) }
         sum
       end
     end
@@ -62,18 +48,6 @@ module Mongoidable
       end
     ensure
       abilities.rule_type = :adhoc
-    end
-
-    def config
-      Mongoidable.configuration
-    end
-
-    def ability_cache_key
-      "#{config.cache_key_prefix}/#{cache_key}"
-    end
-
-    def ability_cache_expiration
-      config.cache_ttl.seconds
     end
   end
 end

--- a/lib/mongoidable/document_extensions.rb
+++ b/lib/mongoidable/document_extensions.rb
@@ -8,16 +8,5 @@ module Mongoidable
     included do
       embeds_many :instance_abilities, class_name: "Mongoidable::Ability"
     end
-
-    class_methods do
-      def _load(args)
-        raw_attributes = Marshal.load(args)
-        instantiate(raw_attributes)
-      end
-    end
-
-    def _dump(*args, &block)
-      Marshal.dump(raw_attributes, *args, &block)
-    end
   end
 end

--- a/lib/mongoidable/instance_abilities.rb
+++ b/lib/mongoidable/instance_abilities.rb
@@ -13,7 +13,7 @@ module Mongoidable
     end
 
     def own_abilities
-      own_abilities = Mongoidable::Abilities.new(mongoidable_identity)
+      own_abilities = Mongoidable::Abilities.new(mongoidable_identity, self)
       instance_abilities.each do |ability|
         if ability.base_behavior
           own_abilities.can(ability.action, ability.subject, *ability.extra)

--- a/lib/mongoidable/rspec/controller_matchers.rb
+++ b/lib/mongoidable/rspec/controller_matchers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec/expectations"
 
 module Mongoidable
@@ -35,7 +37,8 @@ module Mongoidable
           authorize_pairs.map do |authorize_action, authorized_object|
             matcher = receive(:authorize!).with(
                 exact_match(authorize_action),
-                exact_match(authorized_object))
+                exact_match(authorized_object)
+              )
             matcher.setup_expectation(controller)
           end
         end
@@ -45,6 +48,7 @@ module Mongoidable
 
           Mongoidable::RSpec::ExactMatcher.new(value)
         end
+
         def setup_controller
           controller.params.merge! controller_params
           controller.params[:action]     = controller_action

--- a/lib/mongoidable/rspec/exact_matcher.rb
+++ b/lib/mongoidable/rspec/exact_matcher.rb
@@ -7,11 +7,11 @@ module Mongoidable
         @expected = expected
       end
 
-      def ==(value)
-        @expected == value
+      def ==(other)
+        @expected == other
       end
 
-      def ===(value)
+      def ===(_other)
         false
       end
 

--- a/lib/mongoidable/rspec/instance_variable_matcher.rb
+++ b/lib/mongoidable/rspec/instance_variable_matcher.rb
@@ -8,11 +8,9 @@ module Mongoidable
         @subject = subject
       end
 
-      def ==(value)
-        variable_value == value
-      end
+      delegate :==, to: :variable_value
 
-      def ===(value)
+      def ===(_other)
         false
       end
 

--- a/lib/mongoidable/rule.rb
+++ b/lib/mongoidable/rule.rb
@@ -10,64 +10,8 @@ module CanCan
     def initialize(base_behavior, action, subject, *extra_args, &block)
       @rule_source = extra_args.first&.delete(:rule_source)
       @rule_type = extra_args.first&.delete(:rule_type)
-      @abilities = extra_args.first&.delete(:parent)
       extra_args.shift if extra_args.first && extra_args.first.empty?
       super
-    end
-
-    private
-
-    def block_local_variables
-      return {} unless @block
-
-      local_variables = @block.binding.local_variables - [:abilities]
-      local_variables.map do |variable_name|
-        result = @block.binding.local_variable_get(variable_name)
-        variable_value = { value: result }
-        variable_value[:parent_model] = result.parent_model if result.respond_to?(:parent_model)
-        [variable_name, variable_value]
-      rescue TypeError => error
-        raise TypeError, "While dumping #{variable_name} - #{error.message}"
-      end.to_h
-    end
-
-    def marshal_dump
-      Marshal.dump({ base_behavior: @base_behavior,
-                     actions:       @actions,
-                     subjects:      @subjects,
-                     attributes:    @attributes,
-                     conditions:    @conditions,
-                     rule_source:   @rule_source,
-                     rule_type:     @rule_type,
-                     block:         @serialized_block || @block&.source&.strip,
-                     block_locals:  block_local_variables })
-    end
-
-    def marshal_load(hash)
-      hash = Marshal.load(hash)
-      @base_behavior =    hash[:base_behavior]
-      @actions =          hash[:actions]
-      @subjects =         hash[:subjects]
-      @attributes =       hash[:attributes]
-      @conditions =       hash[:conditions]
-      @rule_source =      hash[:rule_source]
-      @rule_type =        hash[:rule_type]
-      @serialized_block = hash[:block]
-      @block_locals =     hash[:block_locals].map do |key, value|
-        result = value[:value]
-        parent = value[:parent_model]
-        result.parent_model = parent if parent
-        [key, result]
-      end.to_h
-      extend Mongoidable.configuration.context_module if Mongoidable.configuration.context_module
-    end
-
-    def method_missing(method, *args, &block)
-      if @block_locals.key?(method)
-        @block_locals[method]
-      else
-        super
-      end
     end
   end
 end

--- a/spec/casl_hash_spec.rb
+++ b/spec/casl_hash_spec.rb
@@ -8,31 +8,37 @@ RSpec.describe "casl_hash" do
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash[:action]).to eq [:action]
   end
+
   it "sets the subject when a symbol" do
     rule = CanCan::Rule.new(false, :action, :subject)
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash[:subject]).to eq [:subject]
   end
+
   it "sets the subject when a class" do
     rule = CanCan::Rule.new(false, :action, User)
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash[:subject]).to eq ["User"]
   end
+
   it "sets the conditions when present" do
     rule = CanCan::Rule.new(false, :action, User, { id: 1 })
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash[:conditions]).to eq({ id: 1 })
   end
+
   it "skips the conditions when not present" do
     rule = CanCan::Rule.new(false, :action, User)
     hash = Mongoidable::CaslHash.new(rule)
-    expect(hash[:conditions]).not_to be
+    expect(hash.key?(:conditions)).to eq false
   end
+
   it "sets inverted when base_behavior is false" do
     rule = CanCan::Rule.new(false, :action, User)
     hash = Mongoidable::CaslHash.new(rule)
     expect(hash[:inverted]).to be_truthy
   end
+
   it "skips inverted when base_behavior is true" do
     rule = CanCan::Rule.new(true, :action, User)
     hash = Mongoidable::CaslHash.new(rule)

--- a/spec/class_abilities_spec.rb
+++ b/spec/class_abilities_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "cancan/matchers"
 RSpec.describe "class_abilities", :with_abilities do
-  after(:each) do
+  after do
     Object.send(:remove_const, :User)
     load "dummy/app/models/user.rb"
   end

--- a/spec/class_type_spec.rb
+++ b/spec/class_type_spec.rb
@@ -5,33 +5,33 @@ require "rails_helper"
 RSpec.describe Mongoidable::ClassType do
   describe "mongoize" do
     it "does not change a string representation of a class" do
-      expect(Mongoidable::ClassType.mongoize("Mongoidable::ClassType")).to eq "Mongoidable::ClassType"
+      expect(described_class.mongoize("Mongoidable::ClassType")).to eq "Mongoidable::ClassType"
     end
 
     it "converts a class to a string" do
-      expect(Mongoidable::ClassType.mongoize(Mongoidable::ClassType)).to eq "Mongoidable::ClassType"
+      expect(described_class.mongoize(described_class)).to eq "Mongoidable::ClassType"
     end
 
     it "converts nil to empty string" do
-      expect(Mongoidable::ClassType.mongoize(nil)).to eq ""
+      expect(described_class.mongoize(nil)).to eq ""
     end
 
     it "converts a symbol to a string" do
-      expect(Mongoidable::ClassType.mongoize(:asdf)).to eq "asdf"
+      expect(described_class.mongoize(:asdf)).to eq "asdf"
     end
   end
 
   describe "demongoize" do
     it "converts a string to a class" do
-      expect(Mongoidable::ClassType.demongoize("Mongoidable::ClassType")).to eq Mongoidable::ClassType
+      expect(described_class.demongoize("Mongoidable::ClassType")).to eq described_class
     end
 
     it "converts empty string to nil" do
-      expect(Mongoidable::ClassType.demongoize("")).to eq nil
+      expect(described_class.demongoize("")).to eq nil
     end
 
     it "converts a string to a symbol" do
-      expect(Mongoidable::ClassType.demongoize("asdf")).to eq :asdf
+      expect(described_class.demongoize("asdf")).to eq :asdf
     end
   end
 end

--- a/spec/dummy/app/models/inheritance.rb
+++ b/spec/dummy/app/models/inheritance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Inheritance < User
-  belongs_to :parent3, class_name: "Parent3", required: false
+  belongs_to :parent3, class_name: "Parent3", optional: true
 
   inherits_abilities_from(:parent3)
 

--- a/spec/dummy/app/models/parent1.rb
+++ b/spec/dummy/app/models/parent1.rb
@@ -4,8 +4,16 @@ class Parent1
   include Mongoid::Document
   include Mongoidable::Document
 
-  define_abilities do |abilities, _model|
+  define_abilities do |abilities, model|
     abilities.can :do_parent1_class_stuff, User
     abilities.cannot :do_parent2_class_stuff, User
+    abilities.can :do_nested_stuff, User do |other_user|
+      model.tap do |tapped|
+        tapped.to_s
+        other_user.to_s
+        tapped.to_s
+      end
+      true
+    end
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -6,8 +6,8 @@ class User
 
   field :name, type: String
 
-  belongs_to :parent1, class_name: "Parent1", required: false
-  belongs_to :parent2, class_name: "Parent2", required: false
+  belongs_to :parent1, class_name: "Parent1", optional: true
+  belongs_to :parent2, class_name: "Parent2", optional: true
   embeds_many :embedded_parents, class_name: "Parent1"
   inherits_abilities_from(:parent1)
   inherits_abilities_from(:parent2)

--- a/spec/models/abilities_spec.rb
+++ b/spec/models/abilities_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe Mongoidable::Abilities do
           }
       ]
     end
+
     it "produces a casl list of rules" do
-      abilities = Mongoidable::Abilities.new("test")
+      abilities = described_class.new("test", nil)
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|
@@ -49,7 +50,7 @@ RSpec.describe Mongoidable::Abilities do
     it "produces a casl list of rules without js closure" do
       allow(Mongoidable.configuration).to receive(:serialize_js).and_return(false)
 
-      abilities = Mongoidable::Abilities.new("test")
+      abilities = described_class.new("test", nil)
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|
@@ -64,7 +65,7 @@ RSpec.describe Mongoidable::Abilities do
     it "produces a casl list of rules without ruby block" do
       allow(Mongoidable.configuration).to receive(:serialize_ruby).and_return(false)
 
-      abilities = Mongoidable::Abilities.new("test")
+      abilities = described_class.new("test", nil)
       abilities.can(:do_thing, :to_thing)
       abilities.cannot(:do_other_thing, User, { name: "Fred" })
       abilities.can(:do_block_thing, User) do |user|

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -4,40 +4,40 @@ require "rails_helper"
 
 RSpec.describe Mongoidable::Ability, :with_abilities do
   it "accepts a class as the subject" do
-    ability = Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: Mongoid::Document)
+    ability = described_class.new(base_behavior: true, action: :do_something, subject: Mongoid::Document)
     expect(ability).to be_valid
     expect(ability.subject).to eq Mongoid::Document
   end
 
   it "accepts a symbol as the subject" do
-    ability = Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: :asdf)
+    ability = described_class.new(base_behavior: true, action: :do_something, subject: :asdf)
     expect(ability).to be_valid
     expect(ability.subject).to eq :asdf
   end
 
   it "accepts an attribute validation" do
     main_instance = User.new(id: 1)
-    main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
+    main_instance.instance_abilities << described_class.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
     expect(main_instance).to be_valid
     main_instance.save
     other_instance = User.new(id: 2)
     expect(other_instance).to be_valid
     other_instance.save
 
-    expect(main_instance.current_ability.can?(:do_something, other_instance)).to be_truthy
-    expect(main_instance.current_ability.can?(:do_something, main_instance)).to  be_falsey
+    expect(main_instance.current_ability).to be_can(:do_something, other_instance)
+    expect(main_instance.current_ability).not_to be_can(:do_something, main_instance)
   end
 
   it "adds the instance ability source to the rule" do
     main_instance = User.new(id: 1)
-    main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
+    main_instance.instance_abilities << described_class.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
     list = main_instance.current_ability.to_casl_list
     expect(list[2][:source]).to eq({ id: 1, model: "User" })
   end
 
   it "adds the ability action description to the rule" do
     main_instance = User.new(id: 1)
-    main_instance.instance_abilities << Mongoidable::Ability.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
+    main_instance.instance_abilities << described_class.new(base_behavior: true, action: :do_something, subject: User, extra: [{ id: 2 }])
     allow(I18n).to receive(:t).
         with("mongoidable.ability.description.do_user_class_stuff", { subject: ["User"] }).
         and_return("This is my do_user_class_stuff description")

--- a/spec/mongoid_ext_spec.rb
+++ b/spec/mongoid_ext_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "mongoid_ext", :with_abilities do
 
       expect(user.current_ability.permissions).to eq({
                                                          can:    {
+                                                             do_nested_stuff:            { "User"=>[] },
                                                              do_parent1_class_stuff:     { "User" => [] },
                                                              do_parent1_instance_things: { "on_something" => [] },
                                                              do_parent2_class_stuff:     { "User" => [] },

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ require "mongoidable/rspec"
 
 require_relative "support/database_cleaner"
 require_relative "support/mongoidable"
+require_relative "support/rails_cache"
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
-  config.around(:each) do |example|
+  config.around do |example|
     DatabaseCleaner.clean
 
     example.run

--- a/spec/support/rails_cache.rb
+++ b/spec/support/rails_cache.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "database_cleaner"
+
+RSpec.configure do |config|
+  config.before do
+    Rails.cache.clear
+  end
+end


### PR DESCRIPTION
Switches caching to be based on the can? and cannot? methods.
Duh! Why didn't I think of that before? Well, we didn't have the parent_model stuff in place before. That came after caching so I didn't stretch that far. parent_model is necessary in order to determine cache keys.