### PR TITLE
US5299 - Export attributes with policies.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongoidable (0.1.3)
+    mongoidable (0.1.4)
       ParseTree
       active_model_serializers
       cancancan
@@ -76,7 +76,7 @@ GEM
     bcrypt (3.1.16)
     bson (4.12.0)
     builder (3.2.4)
-    cancancan (3.2.1)
+    cancancan (3.2.2)
     cancancan-mongoid (2.0.0)
       cancancan (>= 2.0, < 4)
     cancancan_pub_sub (0.1.0)
@@ -229,7 +229,7 @@ GEM
     unicode-display_width (2.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
 

--- a/app/controllers/mongoidable/policies_controller.rb
+++ b/app/controllers/mongoidable/policies_controller.rb
@@ -8,23 +8,23 @@ module Mongoidable
     authorize_resource class: "Mongoidable::Policy"
 
     def index
-      render json: policy, root: :policies
+      render json: policy, root: :policies, namespace: ::Mongoidable
     end
 
     def show
-      render json: policy, root: :policies
+      render json: policy, root: :policies, namespace: ::Mongoidable
     end
 
     def create
       policy.save!
 
-      render json: policy, root: :policies
+      render json: policy, root: :policies, namespace: ::Mongoidable
     end
 
     def update
       policy.save!
 
-      render json: policy, root: :policies
+      render json: policy, root: :policies, namespace: ::Mongoidable
     end
 
     def destroy

--- a/app/serializers/mongoidable/ability_serializer.rb
+++ b/app/serializers/mongoidable/ability_serializer.rb
@@ -4,6 +4,7 @@ module Mongoidable
   # Default serializer for policies
   class AbilitySerializer < ActiveModel::Serializer
     attributes :action, :base_behavior, :extra
+    attribute(:_id) { object.id.to_s }
     attribute(:subject) do
       Mongoidable::ClassType.mongoize(object.subject)
     end

--- a/app/serializers/mongoidable/concerns/serializes_instance_abilities.rb
+++ b/app/serializers/mongoidable/concerns/serializes_instance_abilities.rb
@@ -7,7 +7,7 @@ module Mongoidable
 
       included do
         has_many :instance_abilities do
-          object.instance_abilities.map(&:id).map(&:to_s)
+          object.instance_abilities.map { |instance_ability| instance_ability.id.to_s }
         end
       end
     end

--- a/app/serializers/mongoidable/concerns/serializes_instance_abilities.rb
+++ b/app/serializers/mongoidable/concerns/serializes_instance_abilities.rb
@@ -7,7 +7,7 @@ module Mongoidable
 
       included do
         has_many :instance_abilities do
-          object.instance_abilities.map(&:id)
+          object.instance_abilities.map(&:id).map(&:to_s)
         end
       end
     end

--- a/app/serializers/mongoidable/policy_serializer.rb
+++ b/app/serializers/mongoidable/policy_serializer.rb
@@ -4,8 +4,12 @@ module Mongoidable
   # Default serializer for policies
   class PolicySerializer < ActiveModel::Serializer
     include Mongoidable::Concerns::SerializesInstanceAbilities
-    def attributes(*_args)
-      object.attributes.symbolize_keys
+    include Mongoidable::Concerns::SerializesCaslAbilities
+
+    attribute(:_id) { object.id.to_s }
+
+    def attributes(*args)
+      super(*args).reverse_merge(object.attributes.symbolize_keys)
     end
   end
 end

--- a/lib/mongoidable/version.rb
+++ b/lib/mongoidable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoidable
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/controllers/policies_controller_spec.rb
+++ b/spec/controllers/policies_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Mongoidable::PoliciesController, type: :controller do
     describe "index" do
       routes { Mongoidable::Engine.routes }
       it "returns user type policies" do
-        database_policies = 10.times do |index|
+        database_policies = Array.new(10) do |index|
           Mongoidable::Policy.create(
               name:               index,
               owner_type:         "user",
@@ -105,10 +105,8 @@ RSpec.describe Mongoidable::PoliciesController, type: :controller do
 
         get :index, params: { owner_type: "user" }
         expect(response).to be_ok
-        policies = JSON.parse(response.body)["abilities/policies"]
+        policies = JSON.parse(response.body)["policies"]
         verify_policies(policies, database_policies)
-      rescue StandardError => error
-        error
       end
     end
 
@@ -205,7 +203,7 @@ RSpec.describe Mongoidable::PoliciesController, type: :controller do
       response_policies.each do |policy|
         db_policy = db_policies.detect { |db| policy["_id"] == db.id.to_s }
         expect(policy["name"]).to eq(db_policy["name"])
-        expect(policy["type"]).to eq("user")
+        expect(policy["owner_type"]).to eq("user")
 
         db_abilities = db_policy.instance_abilities.to_a
         policy["abilities"].each_with_index do |ability, index|

--- a/spec/serializers/policy_serializer_spec.rb
+++ b/spec/serializers/policy_serializer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mongoidable::PolicySerializer do
                                          action:        :action,
                                          subject:       :subject,
                                          id:            "ability_id"
-                                       )])
+                                     )])
 
     output = Mongoidable::PolicySerializer.new(policy).as_json
 
@@ -22,5 +22,12 @@ RSpec.describe Mongoidable::PolicySerializer do
     expect(output[:description]).to eq policy.description.to_s
     expect(output[:owner_type]).to eq policy.owner_type.to_s
     expect(output[:instance_abilities]).to eq ["ability_id"]
+
+    expect(output[:abilities]).to eq [{ action:      [:action],
+                                        description: "translation missing: en.mongoidable.ability.description.action",
+                                        has_block:   false,
+                                        source:      { :id => "id", :model => "Mongoidable::Policy" },
+                                        subject:     [:subject],
+                                        type:        :adhoc }]
   end
 end


### PR DESCRIPTION
https://rally1.rallydev.com/#/18313249162d/iterationstatus?detail=%2Fuserstory%2F605830800740

When serializing Policies, include the CASL abilities array.