### PR TITLE
US5649 unset calls hooks

### DIFF
--- a/lib/mongoidable/ability_updater.rb
+++ b/lib/mongoidable/ability_updater.rb
@@ -26,7 +26,7 @@ module Mongoidable
     end
 
     def destroy_ability
-      instance_abilities.delete database_ability
+      database_ability.destroy!
     end
 
     def create_ability

--- a/lib/mongoidable/version.rb
+++ b/lib/mongoidable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongoidable
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/spec/ability_updater_spec.rb
+++ b/spec/ability_updater_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe Mongoidable::AbilityUpdater do
     expect(ability).to be_a(Mongoidable::SpecificAbility)
   end
 
+  it "calls the callbacks on a class if unset" do
+    updater = Mongoidable::AbilityUpdater.new(user, { action: :specific_ability, subject: :specific_subject, base_behavior: true })
+    updater.call
+
+    updater = Mongoidable::AbilityUpdater.new(user, { action: :specific_ability, subject: :specific_subject, extra: [], base_behavior: false })
+    expect { updater.call }.to raise_error "Testing that destroy is called"
+  end
+
   it "creates an ability by class if appropriate if subject is hash" do
     updater = Mongoidable::AbilityUpdater.new(user,
                                               { action:        :specific_ability,

--- a/spec/dummy/app/models/abilities/specific_ability.rb
+++ b/spec/dummy/app/models/abilities/specific_ability.rb
@@ -6,12 +6,20 @@ module Mongoidable
       super base_behavior: true, action: :specific_ability, subject: :specific_subject, extra: []
     end
 
+    after_destroy :raise_error
+
     def self.ability
       :specific_ability
     end
 
     def self.valid_for?(parent_class)
       parent_class == User
+    end
+
+    private
+
+    def raise_error
+      raise "Testing that destroy is called"
     end
   end
 end


### PR DESCRIPTION
use destroy to get callback hooks instead of delete.

## RALLY STORY

https://rally1.rallydev.com/#/18313249162d/iterationstatus?detail=%2Fuserstory%2F630218671627
https://github.com/CardTapp/mortgagemapp/pull/8029
